### PR TITLE
Included support for minikube installation in Debian/Ubuntu Linux distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## What is gokube?
 
-gokube is a tool that simplifies day-to-day development with [Kubernetes](https://github.com/kubernetes/kubernetes) on your laptop under Windows.
+gokube is a tool that simplifies day-to-day development with [Kubernetes](https://github.com/kubernetes/kubernetes) on your laptop under Windows or Debian/Ubuntu.
 
 gokube downloads and installs several dependencies such as:
 * [minikube](https://github.com/kubernetes/minikube)
@@ -41,6 +41,68 @@ $ gokube init
 ```
 
 ## How to install gokube?
+
+### Debian / Ubuntu
+
+#### Requirements
+* [VirtualBox](https://www.virtualbox.org/wiki/Linux_Downloads)
+* VT-x/AMD-v virtualization must be enabled in BIOS/UEFI
+* Internet connection for the first run
+* Go 1.23 or later if you build gokube locally
+
+#### Configure VirtualBox host-only networks
+
+gokube uses the minikube VirtualBox host-only CIDR `192.168.99.1/24`. On recent VirtualBox versions for Linux hosts, host-only adapters are restricted to `192.168.56.0/21` unless additional ranges are allowed in `/etc/vbox/networks.conf`.
+
+Allow gokube's host-only network before running `gokube init`:
+
+```shell
+$ sudo mkdir -p /etc/vbox
+$ echo '* 192.168.99.0/24' | sudo tee /etc/vbox/networks.conf
+```
+
+#### Build the Linux executable
+
+From the repository root, build a Linux amd64 executable:
+
+```shell
+$ GOOS=linux GOARCH=amd64 go build -o bin/gokube-linux-amd64 ./cmd/gokube
+```
+
+If you are building directly on the target Debian/Ubuntu machine, you can also use:
+
+```shell
+$ go build -o bin/gokube ./cmd/gokube
+```
+
+#### Install the executable
+
+Copy or move the executable to a directory in your PATH. For example:
+
+```shell
+$ mkdir -p ~/.local/bin
+$ cp bin/gokube-linux-amd64 ~/.local/bin/gokube
+$ chmod +x ~/.local/bin/gokube
+```
+
+Make sure `~/.local/bin` is in your PATH before running gokube.
+
+#### Initialize gokube
+
+gokube uses the minikube VirtualBox driver by default. On Debian/Ubuntu, VirtualBox must be installed and `VBoxManage` must be available in your PATH.
+
+```shell
+$ gokube init -cu --memory=12288Mb --cpus=6 --disk=12Gb
+```
+
+If minikube gets `192.168.99.101` instead of the expected `192.168.99.100`, delete the failed VM and clear VirtualBox DHCP lease files before retrying:
+
+```shell
+$ minikube delete
+$ rm -f ~/.VirtualBox/HostInterfaceNetworking-vboxnet*-Dhcpd.*
+$ rm -f ~/.config/VirtualBox/HostInterfaceNetworking-vboxnet*-Dhcpd.*
+$ gokube init -cu --memory=12288Mb --cpus=6 --disk=12Gb
+```
 
 ### Windows
 
@@ -271,4 +333,3 @@ Starting minikube VM with kubernetes v1.31.0 and container runtime "docker"...
 
 * [**Contributing**](./CONTRIBUTING.md)
 * [**Development Guide**](./docs/developer-guide.md)
-

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -23,11 +23,11 @@ import (
 	"github.com/gemalto/gokube/pkg/utils"
 	"github.com/gemalto/gokube/pkg/virtualbox"
 	"github.com/spf13/viper"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
-	"net/http"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/gemalto/gokube/pkg/gokube"
@@ -38,7 +38,7 @@ import (
 	"os/exec"
 )
 
-var memory int16
+var memory string
 var cpus int16
 var swap int16
 var enableSwap bool
@@ -66,7 +66,7 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
-	defaultVMMemory, _ := strconv.Atoi(utils.GetValueFromEnv("MINIKUBE_MEMORY", strconv.Itoa(DEFAULT_MINIKUBE_MEMORY)))
+	defaultVMMemory := utils.GetValueFromEnv("MINIKUBE_MEMORY", fmt.Sprintf("%dMb", DEFAULT_MINIKUBE_MEMORY))
 	defaultVMCPUs, _ := strconv.Atoi(utils.GetValueFromEnv("MINIKUBE_CPUS", strconv.Itoa(DEFAULT_MINIKUBE_CPUS)))
 	defaultVMSwap, _ := strconv.Atoi(utils.GetValueFromEnv("MINIKUBE_SWAP", strconv.Itoa(DEFAULT_MINIKUBE_SWAP)))
 	enableSwap = false
@@ -80,13 +80,14 @@ func init() {
 	loadURLVersionsFromEnv()
 	initCmd.Flags().StringVarP(&kubernetesVersion, "kubernetes-version", "", utils.GetValueFromEnv("KUBERNETES_VERSION", DEFAULT_KUBERNETES_VERSION), "The kubernetes version")
 	initCmd.Flags().StringVarP(&containerRuntime, "container-runtime", "", utils.GetValueFromEnv("MINIKUBE_CONTAINER_RUNTIME", DEFAULT_MINIKUBE_CONTAINER_RUNTIME), "Minikube container runtime (docker, cri-o, containerd)")
+	initCmd.Flags().StringVarP(&minikubeDriver, "driver", "", utils.GetValueFromEnv("MINIKUBE_DRIVER", defaultMinikubeDriver()), "Minikube driver")
 	initCmd.Flags().BoolVarP(&askForUpgrade, "upgrade", "u", false, "Upgrade gokube (download and setup docker, minikube, kubectl and helm)")
 	initCmd.Flags().BoolVarP(&askForClean, "clean", "c", false, "Clean gokube (remove docker, minikube, kubectl and helm working directories)")
-	initCmd.Flags().Int16VarP(&memory, "memory", "", int16(defaultVMMemory), "Amount of RAM allocated to the minikube VM in MB")
+	initCmd.Flags().StringVarP(&memory, "memory", "", defaultVMMemory, "Amount of RAM allocated to the minikube VM")
 	initCmd.Flags().Int16VarP(&cpus, "cpus", "", int16(defaultVMCPUs), "Number of CPUs allocated to the minikube VM")
 	initCmd.Flags().Int16VarP(&swap, "swap", "", int16(defaultVMSwap), "Amount of SWAP allocated to the minikube VM in MB")
 	initCmd.Flags().StringVarP(&disk, "disk", "", utils.GetValueFromEnv("MINIKUBE_DISK", DEFAULT_MINIKUBE_DISK), "Disk size allocated to the minikube VM. Format: <number>[<unit>], where unit = b, k, m or g")
-	initCmd.Flags().StringVarP(&checkIP, "check-ip", "", utils.GetValueFromEnv("GOKUBE_CHECK_IP", DEFAULT_GOKUBE_CHECK_IP), "Checks if minikube VM allocated IP matches the provided one (0.0.0.0 means no check)")
+	initCmd.Flags().StringVarP(&checkIP, "check-ip", "", utils.GetValueFromEnv("GOKUBE_CHECK_IP", defaultGokubeCheckIP()), "Checks if minikube VM allocated IP matches the provided one (0.0.0.0 means no check)")
 	initCmd.Flags().StringVarP(&insecureRegistry, "insecure-registry", "", os.Getenv("INSECURE_REGISTRY"), "Insecure Docker registries to pass to the Docker daemon. The default service CIDR range will automatically be added.")
 	initCmd.Flags().StringVarP(&httpProxy, "http-proxy", "", os.Getenv("HTTP_PROXY"), "HTTP proxy variable for docker engine in minikube VM")
 	initCmd.Flags().StringVarP(&httpsProxy, "https-proxy", "", os.Getenv("HTTPS_PROXY"), "HTTPS proxy variable for docker engine in minikube VM")
@@ -270,7 +271,7 @@ func initRun(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			fmt.Printf("Warning: cannot delete previous minikube VM: %s\n", err)
 		}
-		if ipCheckNeeded {
+		if ipCheckNeeded && minikubeDriver == "virtualbox" {
 			err = resetVBLease(DEFAULT_GOKUBE_CIDR)
 			if err != nil {
 				return fmt.Errorf("cannot delete previous minikube VM: %w", err)
@@ -303,20 +304,22 @@ func initRun(cmd *cobra.Command, args []string) error {
 
 		// Create virtual machine (minikube)
 		fmt.Printf("Creating minikube VM with kubernetes %s...\n", kubernetesVersion)
-		err := minikube.Start(memory, cpus, disk, httpProxy, httpsProxy, noProxy, insecureRegistry, kubernetesVersion, true, dnsProxy, hostDNSResolver, dnsDomain, containerRuntime, force, verbose)
+		err := minikube.Start(memory, cpus, disk, minikubeDriver, httpProxy, httpsProxy, noProxy, insecureRegistry, kubernetesVersion, true, dnsProxy, hostDNSResolver, dnsDomain, containerRuntime, force, verbose)
 		if err != nil {
 			return fmt.Errorf("cannot start minikube VM: %w", err)
 		}
 
-        // Create & attach swap drive to minikube
-        if enableSwap {
-            fmt.Println("Creating & attaching swap drive to minikube VM...")
-            vboxManager := virtualbox.NewVBoxManager()
-            err = vboxManager.AddSwapDisk(swap)
-            if err != nil {
-                fmt.Printf("Warning: cannot create & attach swap drive to minikube VM: %s\n", err)
-            }
-        }
+		// Create & attach swap drive to minikube
+		if enableSwap && minikubeDriver == "virtualbox" {
+			fmt.Println("Creating & attaching swap drive to minikube VM...")
+			vboxManager := virtualbox.NewVBoxManager()
+			err = vboxManager.AddSwapDisk(swap)
+			if err != nil {
+				fmt.Printf("Warning: cannot create & attach swap drive to minikube VM: %s\n", err)
+			}
+		} else if enableSwap {
+			fmt.Printf("Warning: swap disk setup is only supported with the virtualbox driver, skipping for %s\n", minikubeDriver)
+		}
 
 		// Enable dashboard
 		err = minikube.AddonsEnable("dashboard")
@@ -372,19 +375,19 @@ func initRun(cmd *cobra.Command, args []string) error {
 	}
 
 	// Keep kubernetes version in a persistent file to remember the right kubernetes version to set for (re)start command
-	err = gokube.WriteConfig(gokubeVersion, kubernetesVersion, containerRuntime)
+	err = gokube.WriteConfig(gokubeVersion, kubernetesVersion, containerRuntime, minikubeDriver)
 	if err != nil {
 		return fmt.Errorf("cannot write gokube configuration: %w", err)
 	}
 
-    // Format & enable swap drive in minikube VM
-    if enableSwap {
-        fmt.Println("Formatting & enabling swap drive in minikube VM...")
-	    err = addSwapToMinikube()
-	    if err != nil {
-		    fmt.Printf("Warning: cannot format/enable swap drive in minikube VM: %s\n", err)
-	    }
-    }
+	// Format & enable swap drive in minikube VM
+	if enableSwap && minikubeDriver == "virtualbox" {
+		fmt.Println("Formatting & enabling swap drive in minikube VM...")
+		err = addSwapToMinikube()
+		if err != nil {
+			fmt.Printf("Warning: cannot format/enable swap drive in minikube VM: %s\n", err)
+		}
+	}
 
 	fmt.Printf("\ngokube init completed in %s\n", util.Duration(time.Since(startTime)))
 	return nil

--- a/cmd/gokube/cmd/pause.go
+++ b/cmd/gokube/cmd/pause.go
@@ -16,6 +16,8 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/gemalto/gokube/pkg/gokube"
+	"github.com/gemalto/gokube/pkg/minikube"
 	"github.com/gemalto/gokube/pkg/virtualbox"
 	"github.com/spf13/cobra"
 )
@@ -40,8 +42,21 @@ func pauseRun(cmd *cobra.Command, args []string) error {
 
 	checkLatestVersion()
 
+	err := gokube.ReadConfig(verbose)
+	if err != nil {
+		return fmt.Errorf("cannot read gokube configuration file: %w", err)
+	}
+
 	fmt.Println("Pausing minikube VM...")
-	err := virtualbox.Pause()
+	if configuredMinikubeDriver() != "virtualbox" {
+		err = minikube.Pause()
+		if err != nil {
+			return fmt.Errorf("cannot pause minikube VM: %w", err)
+		}
+		return nil
+	}
+
+	err = virtualbox.Pause()
 	if err != nil {
 		return fmt.Errorf("cannot pause minikube VM: %w", err)
 	}

--- a/cmd/gokube/cmd/reset.go
+++ b/cmd/gokube/cmd/reset.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/gemalto/gokube/pkg/gokube"
 	"github.com/gemalto/gokube/pkg/minikube"
 	"github.com/gemalto/gokube/pkg/utils"
 	"github.com/gemalto/gokube/pkg/virtualbox"
@@ -36,6 +37,14 @@ func resetRun(cmd *cobra.Command, args []string) error {
 	}
 
 	checkLatestVersion()
+
+	err := gokube.ReadConfig(verbose)
+	if err != nil {
+		return fmt.Errorf("cannot read gokube configuration file: %w", err)
+	}
+	if configuredMinikubeDriver() != "virtualbox" {
+		return fmt.Errorf("save/reset snapshots are only supported with the virtualbox driver")
+	}
 
 	running, err := virtualbox.IsRunning()
 	if err != nil {

--- a/cmd/gokube/cmd/resume.go
+++ b/cmd/gokube/cmd/resume.go
@@ -16,6 +16,8 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/gemalto/gokube/pkg/gokube"
+	"github.com/gemalto/gokube/pkg/minikube"
 	"github.com/gemalto/gokube/pkg/virtualbox"
 	"github.com/spf13/cobra"
 )
@@ -40,8 +42,21 @@ func resumeRun(cmd *cobra.Command, args []string) error {
 
 	checkLatestVersion()
 
+	err := gokube.ReadConfig(verbose)
+	if err != nil {
+		return fmt.Errorf("cannot read gokube configuration file: %w", err)
+	}
+
 	fmt.Println("Resuming minikube VM...")
-	err := virtualbox.Resume()
+	if configuredMinikubeDriver() != "virtualbox" {
+		err = minikube.Unpause()
+		if err != nil {
+			return fmt.Errorf("cannot resume minikube VM: %w", err)
+		}
+		return nil
+	}
+
+	err = virtualbox.Resume()
 	if err != nil {
 		return fmt.Errorf("cannot resume minikube VM: %w", err)
 	}

--- a/cmd/gokube/cmd/root.go
+++ b/cmd/gokube/cmd/root.go
@@ -25,12 +25,13 @@ import (
 	"github.com/gemalto/gokube/pkg/helmimage"
 	"github.com/gemalto/gokube/pkg/helmpush"
 	"github.com/gemalto/gokube/pkg/helmspray"
+	"github.com/gemalto/gokube/pkg/k9s"
 	"github.com/gemalto/gokube/pkg/kubectl"
 	"github.com/gemalto/gokube/pkg/minikube"
 	"github.com/gemalto/gokube/pkg/stern"
-	"github.com/gemalto/gokube/pkg/k9s"
 	"github.com/gemalto/gokube/pkg/utils"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"os"
 )
 
@@ -44,6 +45,7 @@ const (
 	DEFAULT_MINIKUBE_DISK              = "20g"
 	DEFAULT_MINIKUBE_DNS_DOMAIN        = "cluster.local"
 	DEFAULT_MINIKUBE_CONTAINER_RUNTIME = "docker"
+	DEFAULT_MINIKUBE_DRIVER            = "virtualbox"
 	DEFAULT_DOCKER_VERSION             = "29.2.1"
 	DEFAULT_HELM_VERSION               = "v3.20.0"
 	DEFAULT_HELM_SPRAY_VERSION         = "v4.0.13"
@@ -58,6 +60,7 @@ const (
 
 var kubernetesVersion string
 var containerRuntime string
+var minikubeDriver string
 var kubectlURL string
 var kubectlVersion string
 var minikubeURL string
@@ -136,6 +139,22 @@ func loadURLVersionsFromEnv() {
 	sternVersion = utils.GetValueFromEnv("STERN_VERSION", DEFAULT_STERN_VERSION)
 	k9sURL = utils.GetValueFromEnv("K9S_URL", k9s.DEFAULT_URL)
 	k9sVersion = utils.GetValueFromEnv("K9S_VERSION", DEFAULT_K9S_VERSION)
+}
+
+func defaultMinikubeDriver() string {
+	return DEFAULT_MINIKUBE_DRIVER
+}
+
+func defaultGokubeCheckIP() string {
+	return DEFAULT_GOKUBE_CHECK_IP
+}
+
+func configuredMinikubeDriver() string {
+	driver := viper.GetString("minikube-driver")
+	if len(driver) == 0 {
+		driver = utils.GetValueFromEnv("MINIKUBE_DRIVER", defaultMinikubeDriver())
+	}
+	return driver
 }
 
 func upgradeDependencies() error {

--- a/cmd/gokube/cmd/save.go
+++ b/cmd/gokube/cmd/save.go
@@ -38,11 +38,18 @@ func saveRun(cmd *cobra.Command, args []string) error {
 
 	checkLatestVersion()
 
+	err := gokube.ReadConfig(verbose)
+	if err != nil {
+		return fmt.Errorf("cannot read gokube configuration file: %w", err)
+	}
+	if configuredMinikubeDriver() != "virtualbox" {
+		return fmt.Errorf("save/reset snapshots are only supported with the virtualbox driver")
+	}
+
 	running := false
 	if live && !quiet {
 		gokube.ConfirmSnapshotCommandExecution()
 	} else if !live {
-		var err error
 		running, err = virtualbox.IsRunning()
 		if err != nil {
 			return fmt.Errorf("cannot check if minikube VM is running: %w", err)
@@ -56,7 +63,7 @@ func saveRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 	fmt.Printf("Taking snapshot '%s' of minikube VM...\n", snapshotName)
-	err := virtualbox.DeleteSnapshot(snapshotName)
+	err = virtualbox.DeleteSnapshot(snapshotName)
 	if err != nil && err != virtualbox.ErrSnapshotNotExist {
 		return fmt.Errorf("cannot delete minikube VM snapshot %s: %w", snapshotName, err)
 	}

--- a/cmd/gokube/cmd/start.go
+++ b/cmd/gokube/cmd/start.go
@@ -54,8 +54,9 @@ func start() error {
 	if len(containerRuntimeForStart) == 0 {
 		containerRuntimeForStart = utils.GetValueFromEnv("MINIKUBE_CONTAINER_RUNTIME", DEFAULT_MINIKUBE_CONTAINER_RUNTIME)
 	}
+	driverForStart := configuredMinikubeDriver()
 	vb7workaround := utils.GetValueFromEnv("VB7_WORKAROUND", "")
-	if len(vb7workaround) > 0 {
+	if driverForStart == "virtualbox" && len(vb7workaround) > 0 {
 		virtualbox.Update("--nat-localhostreachable1=on")
 	}
 	fmt.Printf("Starting minikube VM with kubernetes %s and container runtime %q...\n", kubernetesVersionForStart, containerRuntimeForStart)
@@ -65,13 +66,15 @@ func start() error {
 	}
 
 	// Add swap to Minikube VM
-	if enableSwap {
-        fmt.Println("Enabling swap drive in minikube VM...")
-        err = addSwapToMinikubeDuringStart()
-        if err != nil {
-    	    fmt.Printf("Warning: cannot enable swap drive in minikube VM - start: %s\n", err)
-        }
-    }
+	if enableSwap && driverForStart == "virtualbox" {
+		fmt.Println("Enabling swap drive in minikube VM...")
+		err = addSwapToMinikubeDuringStart()
+		if err != nil {
+			fmt.Printf("Warning: cannot enable swap drive in minikube VM - start: %s\n", err)
+		}
+	} else if enableSwap {
+		fmt.Printf("Warning: swap disk setup is only supported with the virtualbox driver, skipping for %s\n", driverForStart)
+	}
 
 	return nil
 }
@@ -100,15 +103,6 @@ func startRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	// Add swap to Minikube VM
-	if enableSwap {
-        fmt.Println("Enabling swap drive in minikube VM...")
-        err = addSwapToMinikubeDuringStart()
-        if err != nil {
-    	    fmt.Printf("Warning: cannot enable swap drive in minikube VM - start: %s\n", err)
-        }
-    }
 
 	return nil
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -21,12 +21,20 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
-const (
-	DEFAULT_URL           = "https://download.docker.com/win/static/stable/x86_64/docker-%s.zip"
-	LOCAL_EXECUTABLE_NAME = "docker.exe"
+var (
+	DEFAULT_URL           = defaultURL()
+	LOCAL_EXECUTABLE_NAME = utils.ExecutableName("docker")
 )
+
+func defaultURL() string {
+	if runtime.GOOS == "linux" {
+		return "https://download.docker.com/linux/static/stable/x86_64/docker-%s.tgz"
+	}
+	return "https://download.docker.com/win/static/stable/x86_64/docker-%s.zip"
+}
 
 // Version ...
 func Version() error {
@@ -46,6 +54,7 @@ func DownloadExecutable(dockerURL string, dockerVersion string) error {
 		if err != nil {
 			return err
 		}
+		return utils.MakeExecutable(localFile)
 	}
 	return nil
 }

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -15,12 +15,14 @@ limitations under the License.
 package download
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gemalto/gokube/pkg/utils"
@@ -116,11 +118,48 @@ func FromUrl(urlTpl string, version string, name string, fileMaps []*FileMap, ds
 			}
 		}
 		fileSrc := tempDir + string(os.PathSeparator) + fileMap.Src
-		err = os.Rename(fileSrc, fileDst)
+		err = moveFile(fileSrc, fileDst)
 		if err != nil {
 			return -1, err
 		}
 	}
 
 	return n, nil
+}
+
+func moveFile(src string, dst string) error {
+	err := os.Rename(src, dst)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, syscall.EXDEV) {
+		return err
+	}
+	if err := copyFile(src, dst); err != nil {
+		_ = os.Remove(dst)
+		return err
+	}
+	return os.Remove(src)
+}
+
+func copyFile(src string, dst string) error {
+	source, err := os.Open(src)
+	defer utils.CloseFile(source)
+	if err != nil {
+		return err
+	}
+
+	sourceInfo, err := source.Stat()
+	if err != nil {
+		return err
+	}
+
+	destination, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, sourceInfo.Mode())
+	defer utils.CloseFile(destination)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(destination, source)
+	return err
 }

--- a/pkg/gokube/gokube.go
+++ b/pkg/gokube/gokube.go
@@ -22,10 +22,10 @@ import (
 	"github.com/gemalto/gokube/pkg/helmimage"
 	"github.com/gemalto/gokube/pkg/helmpush"
 	"github.com/gemalto/gokube/pkg/helmspray"
+	"github.com/gemalto/gokube/pkg/k9s"
 	"github.com/gemalto/gokube/pkg/kubectl"
 	"github.com/gemalto/gokube/pkg/minikube"
 	"github.com/gemalto/gokube/pkg/stern"
-	"github.com/gemalto/gokube/pkg/k9s"
 	"github.com/gemalto/gokube/pkg/utils"
 	"github.com/spf13/viper"
 	"os"
@@ -92,7 +92,7 @@ func ReadConfig(verbose bool) error {
 }
 
 // WriteConfig ...
-func WriteConfig(gokubeVersion string, kubernetesVersion string, containerRuntime string) error {
+func WriteConfig(gokubeVersion string, kubernetesVersion string, containerRuntime string, minikubeDriver string) error {
 	configPath := utils.GetUserHome() + string(os.PathSeparator) + ".gokube"
 	configFile := "config"
 	configFilePath := configPath + string(os.PathSeparator) + "config.yaml"
@@ -114,6 +114,7 @@ func WriteConfig(gokubeVersion string, kubernetesVersion string, containerRuntim
 	viper.Set("gokube-version", gokubeVersion)
 	viper.Set("kubernetes-version", kubernetesVersion)
 	viper.Set("container-runtime", containerRuntime)
+	viper.Set("minikube-driver", minikubeDriver)
 	err := viper.WriteConfig()
 	if err != nil {
 		return err

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -20,14 +20,22 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/gemalto/gokube/pkg/utils"
 )
 
-const (
-	DEFAULT_URL           = "https://get.helm.sh/helm-%s-windows-amd64.zip"
-	LOCAL_EXECUTABLE_NAME = "helm.exe"
+var (
+	DEFAULT_URL           = defaultURL()
+	LOCAL_EXECUTABLE_NAME = utils.ExecutableName("helm")
 )
+
+func defaultURL() string {
+	if runtime.GOOS == "linux" {
+		return "https://get.helm.sh/helm-%s-linux-amd64.tar.gz"
+	}
+	return "https://get.helm.sh/helm-%s-windows-amd64.zip"
+}
 
 // Upgrade ...
 func Upgrade(chart string, version string, release string, namespace string, configuration string, valuesFile string) error {
@@ -88,11 +96,16 @@ func PluginsVersion() error {
 func DownloadExecutable(helmURL string, helmVersion string) error {
 	localFile := utils.GetBinDir("gokube") + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME
 	if _, err := os.Stat(localFile); os.IsNotExist(err) {
-		fileMap := &download.FileMap{Src: "windows-amd64" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME, Dst: LOCAL_EXECUTABLE_NAME}
+		platformDir := "windows-amd64"
+		if runtime.GOOS == "linux" {
+			platformDir = "linux-amd64"
+		}
+		fileMap := &download.FileMap{Src: platformDir + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME, Dst: LOCAL_EXECUTABLE_NAME}
 		_, err = download.FromUrl(helmURL, helmVersion, "helm", []*download.FileMap{fileMap}, filepath.Dir(localFile))
 		if err != nil {
-			return nil
+			return err
 		}
+		return utils.MakeExecutable(localFile)
 	}
 	return nil
 }

--- a/pkg/helmimage/helmimage.go
+++ b/pkg/helmimage/helmimage.go
@@ -19,28 +19,42 @@ import (
 	"github.com/gemalto/gokube/pkg/utils"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
-const (
-	DEFAULT_URL           = "https://github.com/ThalesGroup/helm-image/releases/download/%s/helm-image-windows-amd64.tar.gz"
-	LOCAL_EXECUTABLE_NAME = "helm-image.exe"
+var (
+	DEFAULT_URL           = defaultURL()
+	LOCAL_EXECUTABLE_NAME = utils.ExecutableName("helm-image")
 )
+
+func defaultURL() string {
+	if runtime.GOOS == "linux" {
+		return "https://github.com/ThalesGroup/helm-image/releases/download/%s/helm-image-linux-amd64.tar.gz"
+	}
+	return "https://github.com/ThalesGroup/helm-image/releases/download/%s/helm-image-windows-amd64.tar.gz"
+}
 
 // InstallPlugin ...
 func InstallPlugin(helmImageURI string, helmImageVersion string) error {
-	localFile := utils.GetAppDataHome() + string(os.PathSeparator) +
+	pluginDir := utils.GetAppDataHome() + string(os.PathSeparator) +
 		"helm" + string(os.PathSeparator) +
 		"plugins" + string(os.PathSeparator) +
-		"helm-image" + string(os.PathSeparator) +
-		LOCAL_EXECUTABLE_NAME
+		"helm-image"
+	localFile := pluginDir + string(os.PathSeparator) +
+		"bin" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME
 	if _, err := os.Stat(localFile); os.IsNotExist(err) {
 		fileMap1 := &download.FileMap{Src: "bin" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME, Dst: "bin" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME}
-		fileMap2 := &download.FileMap{Src: "bin" + string(os.PathSeparator) + "containerd.exe", Dst: "bin" + string(os.PathSeparator) + "containerd.exe"}
+		containerdName := utils.ExecutableName("containerd")
+		fileMap2 := &download.FileMap{Src: "bin" + string(os.PathSeparator) + containerdName, Dst: "bin" + string(os.PathSeparator) + containerdName}
 		fileMap3 := &download.FileMap{Src: "plugin.yaml", Dst: "plugin.yaml"}
-		_, err = download.FromUrl(helmImageURI, helmImageVersion, "helm-image", []*download.FileMap{fileMap1, fileMap2, fileMap3}, filepath.Dir(localFile))
+		_, err = download.FromUrl(helmImageURI, helmImageVersion, "helm-image", []*download.FileMap{fileMap1, fileMap2, fileMap3}, pluginDir)
 		if err != nil {
 			return err
 		}
+		if err := utils.MakeExecutable(localFile); err != nil {
+			return err
+		}
+		return utils.MakeExecutable(filepath.Join(filepath.Dir(localFile), containerdName))
 	}
 	return nil
 }

--- a/pkg/helmpush/helmpush.go
+++ b/pkg/helmpush/helmpush.go
@@ -18,28 +18,37 @@ import (
 	"github.com/gemalto/gokube/pkg/download"
 	"github.com/gemalto/gokube/pkg/utils"
 	"os"
-	"path/filepath"
+	"runtime"
 )
 
-const (
-	DEFAULT_URL           = "https://github.com/chartmuseum/helm-push/releases/download/v%s/helm-push_%s_windows_amd64.tar.gz"
-	LOCAL_EXECUTABLE_NAME = "helm-cm-push.exe"
+var (
+	DEFAULT_URL           = defaultURL()
+	LOCAL_EXECUTABLE_NAME = utils.ExecutableName("helm-cm-push")
 )
+
+func defaultURL() string {
+	if runtime.GOOS == "linux" {
+		return "https://github.com/chartmuseum/helm-push/releases/download/v%s/helm-push_%s_linux_amd64.tar.gz"
+	}
+	return "https://github.com/chartmuseum/helm-push/releases/download/v%s/helm-push_%s_windows_amd64.tar.gz"
+}
 
 // InstallPlugin ...
 func InstallPlugin(helmPushURI string, helmPushVersion string) error {
-	localFile := utils.GetAppDataHome() + string(os.PathSeparator) +
+	pluginDir := utils.GetAppDataHome() + string(os.PathSeparator) +
 		"helm" + string(os.PathSeparator) +
 		"plugins" + string(os.PathSeparator) +
-		"helm-push" + string(os.PathSeparator) +
-		LOCAL_EXECUTABLE_NAME
+		"helm-push"
+	localFile := pluginDir + string(os.PathSeparator) +
+		"bin" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME
 	if _, err := os.Stat(localFile); os.IsNotExist(err) {
 		fileMap1 := &download.FileMap{Src: "bin" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME, Dst: "bin" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME}
 		fileMap2 := &download.FileMap{Src: "plugin.yaml", Dst: "plugin.yaml"}
-		_, err = download.FromUrl(helmPushURI, helmPushVersion, "helm-push", []*download.FileMap{fileMap1, fileMap2}, filepath.Dir(localFile))
+		_, err = download.FromUrl(helmPushURI, helmPushVersion, "helm-push", []*download.FileMap{fileMap1, fileMap2}, pluginDir)
 		if err != nil {
 			return err
 		}
+		return utils.MakeExecutable(localFile)
 	}
 	return nil
 }

--- a/pkg/helmspray/helmspray.go
+++ b/pkg/helmspray/helmspray.go
@@ -15,31 +15,41 @@ limitations under the License.
 package helmspray
 
 import (
+	"os"
+	"runtime"
+
 	"github.com/gemalto/gokube/pkg/download"
 	"github.com/gemalto/gokube/pkg/utils"
-	"os"
-	"path/filepath"
 )
 
-const (
-	DEFAULT_URL           = "https://github.com/ThalesGroup/helm-spray/releases/download/%s/helm-spray-windows-amd64.tar.gz"
-	LOCAL_EXECUTABLE_NAME = "helm-spray.exe"
+var (
+	DEFAULT_URL           = defaultURL()
+	LOCAL_EXECUTABLE_NAME = utils.ExecutableName("helm-spray")
 )
+
+func defaultURL() string {
+	if runtime.GOOS == "linux" {
+		return "https://github.com/ThalesGroup/helm-spray/releases/download/%s/helm-spray-linux-amd64.tar.gz"
+	}
+	return "https://github.com/ThalesGroup/helm-spray/releases/download/%s/helm-spray-windows-amd64.tar.gz"
+}
 
 // InstallPlugin ...
 func InstallPlugin(helmSprayURI string, helmSprayVersion string) error {
-	localFile := utils.GetAppDataHome() + string(os.PathSeparator) +
+	pluginDir := utils.GetAppDataHome() + string(os.PathSeparator) +
 		"helm" + string(os.PathSeparator) +
 		"plugins" + string(os.PathSeparator) +
-		"helm-spray" + string(os.PathSeparator) +
-		LOCAL_EXECUTABLE_NAME
+		"helm-spray"
+	localFile := pluginDir + string(os.PathSeparator) +
+		"bin" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME
 	if _, err := os.Stat(localFile); os.IsNotExist(err) {
 		fileMap1 := &download.FileMap{Src: "bin" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME, Dst: "bin" + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME}
 		fileMap2 := &download.FileMap{Src: "plugin.yaml", Dst: "plugin.yaml"}
-		_, err = download.FromUrl(helmSprayURI, helmSprayVersion, "helm-spray", []*download.FileMap{fileMap1, fileMap2}, filepath.Dir(localFile))
+		_, err = download.FromUrl(helmSprayURI, helmSprayVersion, "helm-spray", []*download.FileMap{fileMap1, fileMap2}, pluginDir)
 		if err != nil {
 			return err
 		}
+		return utils.MakeExecutable(localFile)
 	}
 	return nil
 }

--- a/pkg/k9s/k9s.go
+++ b/pkg/k9s/k9s.go
@@ -20,14 +20,22 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/gemalto/gokube/pkg/download"
 )
 
-const (
-	DEFAULT_URL           = "https://github.com/derailed/k9s/releases/download/v%s/k9s_Windows_amd64.zip"
-	LOCAL_EXECUTABLE_NAME = "k9s.exe"
+var (
+	DEFAULT_URL           = defaultURL()
+	LOCAL_EXECUTABLE_NAME = utils.ExecutableName("k9s")
 )
+
+func defaultURL() string {
+	if runtime.GOOS == "linux" {
+		return "https://github.com/derailed/k9s/releases/download/v%s/k9s_Linux_amd64.tar.gz"
+	}
+	return "https://github.com/derailed/k9s/releases/download/v%s/k9s_Windows_amd64.zip"
+}
 
 // Version ...
 func Version() error {
@@ -47,6 +55,7 @@ func DownloadExecutable(k9sURL string, k9sVersion string) error {
 		if err != nil {
 			return err
 		}
+		return utils.MakeExecutable(localFile)
 	}
 	return nil
 }

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -19,15 +19,23 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/gemalto/gokube/pkg/download"
 	"github.com/gemalto/gokube/pkg/utils"
 )
 
-const (
-	DEFAULT_URL           = "https://dl.k8s.io/%s/bin/windows/amd64/kubectl.exe"
-	LOCAL_EXECUTABLE_NAME = "kubectl.exe"
+var (
+	DEFAULT_URL           = defaultURL()
+	LOCAL_EXECUTABLE_NAME = utils.ExecutableName("kubectl")
 )
+
+func defaultURL() string {
+	if runtime.GOOS == "linux" {
+		return "https://dl.k8s.io/%s/bin/linux/amd64/kubectl"
+	}
+	return "https://dl.k8s.io/%s/bin/windows/amd64/kubectl.exe"
+}
 
 // Get ...
 func Get(namespace string, resourceType string, resourceName string, jsonPath string) (string, error) {
@@ -76,6 +84,7 @@ func DownloadExecutable(kubectlURL string, kubectlVersion string) error {
 		if err != nil {
 			return err
 		}
+		return utils.MakeExecutable(localFile)
 	}
 	return nil
 }

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -25,14 +26,24 @@ import (
 	"github.com/gemalto/gokube/pkg/utils"
 )
 
-const (
-	DEFAULT_URL           = "https://storage.googleapis.com/minikube/releases/%s/minikube-windows-amd64.exe"
-	LOCAL_EXECUTABLE_NAME = "minikube.exe"
+var (
+	DEFAULT_URL           = defaultURL()
+	LOCAL_EXECUTABLE_NAME = utils.ExecutableName("minikube")
 )
 
+func defaultURL() string {
+	if runtime.GOOS == "linux" {
+		return "https://storage.googleapis.com/minikube/releases/%s/minikube-linux-amd64"
+	}
+	return "https://storage.googleapis.com/minikube/releases/%s/minikube-windows-amd64.exe"
+}
+
 // Start ...
-func Start(memory int16, cpus int16, diskSize string, httpProxy string, httpsProxy string, noProxy string, insecureRegistry string, kubernetesVersion string, cache bool, dnsProxy bool, hostDNSResolver bool, dnsDomain string, containerRuntime string, force bool, verbose bool) error {
-	var args = []string{"start", "--kubernetes-version", kubernetesVersion, "--insecure-registry", insecureRegistry, "--memory", strconv.FormatInt(int64(memory), 10), "--cpus", strconv.FormatInt(int64(cpus), 10), "--disk-size", diskSize, "--driver=virtualbox", "--host-only-cidr=192.168.99.1/24"}
+func Start(memory string, cpus int16, diskSize string, driver string, httpProxy string, httpsProxy string, noProxy string, insecureRegistry string, kubernetesVersion string, cache bool, dnsProxy bool, hostDNSResolver bool, dnsDomain string, containerRuntime string, force bool, verbose bool) error {
+	var args = []string{"start", "--kubernetes-version", kubernetesVersion, "--insecure-registry", insecureRegistry, "--memory", memory, "--cpus", strconv.FormatInt(int64(cpus), 10), "--disk-size", diskSize, "--driver=" + driver}
+	if driver == "virtualbox" {
+		args = append(args, "--host-only-cidr=192.168.99.1/24")
+	}
 	if len(httpProxy) > 0 {
 		args = append(args, "--docker-env=http_proxy="+httpProxy)
 	}
@@ -45,10 +56,10 @@ func Start(memory int16, cpus int16, diskSize string, httpProxy string, httpsPro
 	if !cache {
 		args = append(args, "--cache-images=false")
 	}
-	if dnsProxy {
+	if driver == "virtualbox" && dnsProxy {
 		args = append(args, "--dns-proxy")
 	}
-	if !hostDNSResolver {
+	if driver == "virtualbox" && !hostDNSResolver {
 		args = append(args, "--host-dns-resolver=false")
 	}
 	if len(dnsDomain) > 0 {
@@ -90,6 +101,22 @@ func Restart(kubernetesVersion string, containerRuntime string, force bool, verb
 // Stop ...
 func Stop() error {
 	cmd := exec.Command("minikube", "stop")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// Pause ...
+func Pause() error {
+	cmd := exec.Command("minikube", "pause")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// Unpause ...
+func Unpause() error {
+	cmd := exec.Command("minikube", "unpause")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -140,11 +167,16 @@ func Ip() (string, error) {
 func DownloadExecutable(minikubeURL string, minikubeVersion string) error {
 	localFile := utils.GetBinDir("gokube") + string(os.PathSeparator) + LOCAL_EXECUTABLE_NAME
 	if _, err := os.Stat(localFile); os.IsNotExist(err) {
-		fileMap := &download.FileMap{Src: "minikube-windows-amd64.exe", Dst: LOCAL_EXECUTABLE_NAME}
+		src := "minikube-windows-amd64.exe"
+		if runtime.GOOS == "linux" {
+			src = "minikube-linux-amd64"
+		}
+		fileMap := &download.FileMap{Src: src, Dst: LOCAL_EXECUTABLE_NAME}
 		_, err = download.FromUrl(minikubeURL, minikubeVersion, "minikube", []*download.FileMap{fileMap}, filepath.Dir(localFile))
 		if err != nil {
 			return err
 		}
+		return utils.MakeExecutable(localFile)
 	}
 	return nil
 }

--- a/pkg/stern/stern.go
+++ b/pkg/stern/stern.go
@@ -20,14 +20,22 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/gemalto/gokube/pkg/download"
 )
 
-const (
-	DEFAULT_URL           = "https://github.com/stern/stern/releases/download/v%s/stern_%s_windows_amd64.tar.gz"
-	LOCAL_EXECUTABLE_NAME = "stern.exe"
+var (
+	DEFAULT_URL           = defaultURL()
+	LOCAL_EXECUTABLE_NAME = utils.ExecutableName("stern")
 )
+
+func defaultURL() string {
+	if runtime.GOOS == "linux" {
+		return "https://github.com/stern/stern/releases/download/v%s/stern_%s_linux_amd64.tar.gz"
+	}
+	return "https://github.com/stern/stern/releases/download/v%s/stern_%s_windows_amd64.tar.gz"
+}
 
 // Version ...
 func Version() error {
@@ -47,6 +55,7 @@ func DownloadExecutable(sternURL string, sternVersion string) error {
 		if err != nil {
 			return err
 		}
+		return utils.MakeExecutable(localFile)
 	}
 	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -28,12 +28,29 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
-	"strings"
+	"runtime"
 )
 
 // GetAppDataHome ...
 func GetAppDataHome() string {
-	return os.Getenv("APPDATA")
+	if runtime.GOOS == "windows" {
+		return os.Getenv("APPDATA")
+	}
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); len(xdgDataHome) > 0 {
+		return xdgDataHome
+	}
+	return filepath.Join(GetUserHome(), ".local", "share")
+}
+
+// GetConfigHome ...
+func GetConfigHome() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("APPDATA")
+	}
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); len(xdgConfigHome) > 0 {
+		return xdgConfigHome
+	}
+	return filepath.Join(GetUserHome(), ".config")
 }
 
 // GetUserHome ...
@@ -48,21 +65,37 @@ func GetUserHome() string {
 
 // GetBinDir ...
 func GetBinDir(executable string) string {
-	path, err := exec.LookPath(executable)
+	executablePath, err := exec.LookPath(executable)
 	if err != nil {
 		fmt.Printf("Error: cannot determine %s directory\n", executable)
 		os.Exit(1)
 	}
 	if errors.Is(err, exec.ErrDot) {
-		path, err = os.Getwd()
+		executablePath, err = os.Getwd()
 		if err != nil {
 			fmt.Printf("Error: cannot determine %s directory\n", executable)
 			os.Exit(1)
 		}
 	} else {
-		path = strings.TrimSuffix(path, string(os.PathSeparator)+"gokube.exe")
+		executablePath = filepath.Dir(executablePath)
 	}
-	return path
+	return executablePath
+}
+
+// ExecutableName returns the platform-specific executable filename.
+func ExecutableName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
+
+// MakeExecutable sets executable bits on downloaded binaries on Unix-like systems.
+func MakeExecutable(filePath string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	return os.Chmod(filePath, 0755)
 }
 
 // CreateDirs ...

--- a/pkg/virtualbox/registry_other.go
+++ b/pkg/virtualbox/registry_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package virtualbox
+
+import "fmt"
+
+func findVBoxInstallDirInRegistry() (string, error) {
+	return "", fmt.Errorf("VirtualBox registry lookup is only available on Windows")
+}

--- a/pkg/virtualbox/registry_windows.go
+++ b/pkg/virtualbox/registry_windows.go
@@ -1,0 +1,22 @@
+package virtualbox
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func findVBoxInstallDirInRegistry() (string, error) {
+	registryKey, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Oracle\VirtualBox`, registry.QUERY_VALUE)
+	if err != nil {
+		return "", fmt.Errorf("can't find VirtualBox registry entries, is VirtualBox really installed properly? %w", err)
+	}
+	defer registryKey.Close()
+
+	installDir, _, err := registryKey.GetStringValue("InstallDir")
+	if err != nil {
+		return "", fmt.Errorf("can't find InstallDir registry key within VirtualBox registries entries, is VirtualBox really installed properly? %w", err)
+	}
+
+	return installDir, nil
+}

--- a/pkg/virtualbox/virtualbox.go
+++ b/pkg/virtualbox/virtualbox.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/gemalto/gokube/pkg/utils"
-	"golang.org/x/sys/windows/registry"
 	"net"
 	"os"
 	"os/exec"
@@ -143,11 +142,7 @@ func ResetHostOnlyNetworkLeases(hostOnlyCIDR string, verbose bool) error {
 	if verbose {
 		fmt.Printf("\nResetHostOnlyNetworkLeases: getHostOnlyAdapter: %s", hostOnlyNet.NetworkName)
 	}
-	filesPattern := utils.GetUserHome() + "/.VirtualBox/" + hostOnlyNet.NetworkName + "*"
-	files, err := filepath.Glob(filesPattern)
-	if err != nil {
-		return fmt.Errorf("not able to get host-only network interface DHCP leases files: %w", err)
-	}
+	files, err := dhcpLeaseFiles(hostOnlyNet)
 	for _, f := range files {
 		if verbose {
 			fmt.Printf("\nResetHostOnlyNetworkLeases: deleting lease file %s...", f)
@@ -160,6 +155,28 @@ func ResetHostOnlyNetworkLeases(hostOnlyCIDR string, verbose bool) error {
 		}
 	}
 	return nil
+}
+
+func dhcpLeaseFiles(hostOnlyNet *hostOnlyNetwork) ([]string, error) {
+	var files []string
+	configDirs := []string{
+		filepath.Join(utils.GetUserHome(), ".VirtualBox"),
+		filepath.Join(utils.GetConfigHome(), "VirtualBox"),
+	}
+	patterns := []string{
+		hostOnlyNet.NetworkName + "*",
+		"HostInterfaceNetworking-" + hostOnlyNet.Name + "-Dhcpd.*",
+	}
+	for _, configDir := range configDirs {
+		for _, pattern := range patterns {
+			matches, err := filepath.Glob(filepath.Join(configDir, pattern))
+			if err != nil {
+				return nil, fmt.Errorf("not able to get host-only network interface DHCP leases files: %w", err)
+			}
+			files = append(files, matches...)
+		}
+	}
+	return files, nil
 }
 
 func listHostOnlyAdapters(vbox VBoxManager) (map[string]*hostOnlyNetwork, error) {
@@ -284,24 +301,6 @@ func detectVBoxManageCmdInPath() string {
 		return path
 	}
 	return cmd
-}
-
-func findVBoxInstallDirInRegistry() (string, error) {
-	registryKey, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Oracle\VirtualBox`, registry.QUERY_VALUE)
-	if err != nil {
-		errorMessage := fmt.Sprintf("Can't find VirtualBox registry entries, is VirtualBox really installed properly? %s", err)
-		return "", fmt.Errorf(errorMessage)
-	}
-
-	defer registryKey.Close()
-
-	installDir, _, err := registryKey.GetStringValue("InstallDir")
-	if err != nil {
-		errorMessage := fmt.Sprintf("Can't find InstallDir registry key within VirtualBox registries entries, is VirtualBox really installed properly? %s", err)
-		return "", fmt.Errorf(errorMessage)
-	}
-
-	return installDir, nil
 }
 
 func parseIPv4Mask(s string) net.IPMask {


### PR DESCRIPTION
I have adapted this script to allow to install this same gokube but into Ubuntu Linux distros.

The way of Windows (mostly) was not touched, and I have included new instructions for Ubuntu Linux OS installation.

Tested on different PCs with Ubuntu 24 and 26.